### PR TITLE
Initial Azure support + VM options

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ them to Puppet Enterprise, and bootstrapping Puppet agent on them.
     * [Beginning with node_orchestration](#beginning-with-node_orchestration)
 1. [Usage - Configuration options and additional functionality](#usage)
 1. [Limitations - OS compatibility, etc.](#limitations)
+1. [Known Issues](#known-issues)
 
 ## Description
 
@@ -110,7 +111,8 @@ Create an EC2 instance with default settings.
 * `image_id`: Overrides the default AMI set in Hiera
 * `ami_user`: Overrides the default AMI username set in Hiera
 * `key_name`: Overrides the default SSH key name set in Hiera
-* `public_ip_address`: Overrides Hiera setting on whether to assign a public IP address
+* `public_ip_address`: Overrides Hiera setting on whether to assign a public IP
+  address. Subnet default takes priority.
 * `security_groups`: Overrides the default SG or list of SGs set in Hiera
 * `subnet`: Overrides the default subnet name set in Hiera
 * `region`: Overrides the default region set in Hiera
@@ -148,3 +150,7 @@ Azure. Not all the settings you might want to control are exposed, but the
 plans as implemented aim to demonstrate various ways those settings can be
 defined: as parameters, in module data, and Hiera. Implementations for other
 cloud providers may look very different from these initial versions.
+
+## Known Issues
+
+The plan parameter `node_orchestration::launch_ec2_instance::public_ip_address` has no effect. The EC2 instance 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Create an EC2 instance with default settings.
 * `image_id`: Overrides the default AMI set in Hiera
 * `ami_user`: Overrides the default AMI username set in Hiera
 * `key_name`: Overrides the default SSH key name set in Hiera
+* `public_ip_address`: Overrides Hiera setting on whether to assign a public IP address
 * `security_groups`: Overrides the default SG or list of SGs set in Hiera
 * `subnet`: Overrides the default subnet name set in Hiera
 * `region`: Overrides the default region set in Hiera

--- a/README.md
+++ b/README.md
@@ -124,12 +124,15 @@ expressed as defaults in Hiera plan data.
 
 Create an Azure VM with default settings.
 
-# `name`: The name of the VM to create
-# `size`: The type of VM to create (small, medium, large)
-# `image_id`: Overrides the default image ID set in Hiera
-# `admin_user`: Overrides the initial VM username set in Hiera
-# `admin_password`: Overrides the initial VM password set in Hiera
-# `resource_group`: Overrides the resource group set in Hiera
+* `name`: The name of the VM to create
+* `size`: The type of VM to create (small, medium, large)
+* `image_id`: Overrides the default image ID set in Hiera
+* `admin_user`: Overrides the initial VM username set in Hiera
+* `admin_password`: Overrides the initial VM password set in Hiera
+* `public_ip_address`: Overrides Hiera setting on whether to assign a public IP address
+* `resource_group`: Overrides the resource group set in Hiera
+* `os_disk_size`: If set, the size of the OS disk in GB. Otherwise, use Azure defaults.
+* `data_disk_sizes`: The sizes of the data disks to attach in GB
 
 The available sizes: small, medium, large; map to VM sizes Standard_B1s,
 Standard_B2s, and Standard_D2s_v3 by default. This can be overridden with the

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Create an EC2 instance with default settings.
 * `subnet`: Overrides the default subnet name set in Hiera
 * `region`: Overrides the default region set in Hiera
 * `os_disk_size`: If set, the size of the OS disk in GB. Otherwise, use EC2 defaults.
+* `role`: Set the `pp_role` extension request (trusted fact) to this value
 
 The available sizes: small, medium, large; map to EC2 instance types t3.small,
 t3.medium, and t3.large by default. This can be overridden with the
@@ -137,6 +138,7 @@ Create an Azure VM with default settings.
 * `resource_group`: Overrides the resource group set in Hiera
 * `os_disk_size`: If set, the size of the OS disk in GB. Otherwise, use Azure defaults.
 * `data_disk_sizes`: The sizes of the data disks to attach in GB
+* `role`: Set the `pp_role` extension request (trusted fact) to this value
 
 The available sizes: small, medium, large; map to VM sizes Standard_B1s,
 Standard_B2s, and Standard_D2s_v3 by default. This can be overridden with the

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Create an EC2 instance with default settings.
 * `security_groups`: Overrides the default SG or list of SGs set in Hiera
 * `subnet`: Overrides the default subnet name set in Hiera
 * `region`: Overrides the default region set in Hiera
+* `os_disk_size`: If set, the size of the OS disk in GB. Otherwise, use EC2 defaults.
 
 The available sizes: small, medium, large; map to EC2 instance types t3.small,
 t3.medium, and t3.large by default. This can be overridden with the

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ can be run from the PE console.
 
 Create an EC2 instance with default settings.
 
-* `name`: The name of the instance to create
+* `instance_name`: The name of the instance to create
 * `size`: The type of instance to create (small, medium, large)
 * `image_id`: Overrides the default AMI set in Hiera
 * `ami_user`: Overrides the default AMI username set in Hiera
@@ -128,7 +128,7 @@ expressed as defaults in Hiera plan data.
 
 Create an Azure VM with default settings.
 
-* `name`: The name of the VM to create
+* `vm_name`: The name of the VM to create
 * `size`: The type of VM to create (small, medium, large)
 * `image_id`: Overrides the default image ID set in Hiera
 * `admin_user`: Overrides the initial VM username set in Hiera

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -2,3 +2,5 @@
 lookup_options:
   node_orchestration::aws::secret_access_key:
     convert_to: "Sensitive"
+  node_orchestration::azure::client_secret:
+    convert_to: "Sensitive"

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,6 +1,6 @@
 ---
 lookup_options:
   node_orchestration::aws::secret_access_key:
-    convert_to: "Sensitive"
+    convert_to: 'Sensitive'
   node_orchestration::azure::client_secret:
-    convert_to: "Sensitive"
+    convert_to: 'Sensitive'

--- a/data/plans.yaml
+++ b/data/plans.yaml
@@ -1,7 +1,14 @@
 ---
 lookup_options:
+  node_orchestration::az_vm_sizes:
+    merge: hash
   node_orchestration::ec2_instance_types:
     merge: hash
+
+node_orchestration::az_vm_sizes:
+  small: 'Standard_B1s'
+  medium: 'Standard_B2s'
+  large: 'Standard_D2s_v3'
 
 node_orchestration::ec2_instance_types:
   small: 't3.small'
@@ -9,5 +16,7 @@ node_orchestration::ec2_instance_types:
   large: 't3.large'
 
 # Provide reasonable default: Ubuntu 22.04
+node_orchestration::az_image_id: 'Ubuntu2204'
+node_orchestration::az_admin_user: 'azureuser'
 node_orchestration::ec2_image_id: 'ami-053b0d53c279acc90'
 node_orchestration::ec2_ami_user: 'ubuntu'

--- a/data/plans.yaml
+++ b/data/plans.yaml
@@ -1,5 +1,7 @@
 ---
 lookup_options:
+  node_orchestration::az_admin_password:
+    convert_to: 'Sensitive'
   node_orchestration::az_vm_sizes:
     merge: hash
   node_orchestration::ec2_instance_types:

--- a/manifests/aws.pp
+++ b/manifests/aws.pp
@@ -10,13 +10,10 @@ class node_orchestration::aws (
   Sensitive $secret_access_key,
   String $region,
 ) {
-  package { [
-    'aws-sdk',
-    'retries',
-  ]:
+  ensure_resource('package', ['aws-sdk', 'retries'], {
     ensure   => installed,
     provider => 'puppet_gem',
-  }
+  })
 
   file { "${settings::confdir}/puppetlabs_aws_credentials.ini":
     ensure => file,

--- a/manifests/aws.pp
+++ b/manifests/aws.pp
@@ -15,6 +15,42 @@ class node_orchestration::aws (
     provider => 'puppet_gem',
   })
 
+  # Manage root user's AWS credentials, especially as used by Bolt 'apply' code
+  file {
+    default:
+      owner => 'root',
+      group => 'root',
+    ;
+
+    '/root/.aws':
+      ensure => directory,
+      mode   => '0755',
+    ;
+
+    '/root/.aws/credentials':
+      ensure => file,
+      mode   => '0400',
+    ;
+  }
+  -> ini_setting {
+    default:
+      ensure  => present,
+      path    => '/root/.aws/credentials',
+      section => 'default',
+    ;
+
+    'root-aws-credentials-aws_access_key_id':
+      setting => 'aws_access_key_id',
+      value   => $access_key_id,
+    ;
+
+    'root-aws-credentials-aws_secret_access_key':
+      setting => 'aws_secret_access_key',
+      value   => $secret_access_key,
+    ;
+  }
+
+  # Manage Puppet agent's AWS credentials
   file { "${settings::confdir}/puppetlabs_aws_credentials.ini":
     ensure => file,
     mode   => '0400',

--- a/manifests/azure.pp
+++ b/manifests/azure.pp
@@ -1,0 +1,62 @@
+# Configure pre-requisites for puppetlabs-azure module
+#
+# @param subscription_id The Azure subscription ID to operate on
+# @param tenant_id The Azure AD tenant ID containing your app registration
+# @param client_id The ID associated with your app registration
+# @param client_secret The password assigned to your app registration
+#
+# @see https://forge.puppet.com/modules/puppetlabs/azure
+class node_orchestration::azure (
+  String $subscription_id,
+  String $tenant_id,
+  String $client_id,
+  Sensitive $client_secret,
+) {
+  $gems = [
+    'azure',
+    'azure_mgmt_compute',
+    'azure_mgmt_storage',
+    'azure_mgmt_resources',
+    'azure_mgmt_network',
+    'hocon',
+    'retries',
+  ]
+
+  ensure_resource('package', $gems, {
+    ensure   => installed,
+    provider => 'puppet_gem',
+  })
+
+  file { "${settings::confdir}/azure.conf":
+    ensure => file,
+    mode   => '0400',
+    owner  => $settings::user,
+    group  => $settings::group,
+  }
+  -> hocon_setting {
+    default:
+      ensure => present,
+      path   => "${settings::confdir}/azure.conf",
+    ;
+
+    'azure-subscription_id':
+      setting => 'azure.subscription_id',
+      value   => $subscription_id,
+    ;
+
+    'azure-tenant_id':
+      setting => 'azure.tenant_id',
+      value   => $tenant_id,
+    ;
+
+    'azure-client_id':
+      setting => 'azure.client_id',
+      value   => $client_id,
+    ;
+
+    'azure-client_secret':
+      setting => 'azure.client_secret',
+      value   => $client_secret,
+    ;
+  }
+}

--- a/manifests/azure.pp
+++ b/manifests/azure.pp
@@ -1,62 +1,31 @@
 # Configure pre-requisites for puppetlabs-azure module
 #
-# @param subscription_id The Azure subscription ID to operate on
 # @param tenant_id The Azure AD tenant ID containing your app registration
 # @param client_id The ID associated with your app registration
 # @param client_secret The password assigned to your app registration
 #
 # @see https://forge.puppet.com/modules/puppetlabs/azure
 class node_orchestration::azure (
-  String $subscription_id,
   String $tenant_id,
   String $client_id,
   Sensitive $client_secret,
 ) {
-  $gems = [
-    'azure',
-    'azure_mgmt_compute',
-    'azure_mgmt_storage',
-    'azure_mgmt_resources',
-    'azure_mgmt_network',
-    'hocon',
-    'retries',
-  ]
+  case $facts['os']['family'] {
+    'Debian': {
+      exec { 'install-azure-cli':
+        command => '/usr/bin/curl -sL https://aka.ms/InstallAzureCLIDeb | /bin/bash',
+        creates => '/usr/bin/az',
+        before  => Exec['azure-cli-login'],
+      }
+    }
 
-  ensure_resource('package', $gems, {
-    ensure   => installed,
-    provider => 'puppet_gem',
-  })
-
-  file { "${settings::confdir}/azure.conf":
-    ensure => file,
-    mode   => '0400',
-    owner  => $settings::user,
-    group  => $settings::group,
+    default: {
+      fail("Azure CLI installation not handled for ${facts['os']['family']}")
+    }
   }
-  -> hocon_setting {
-    default:
-      ensure => present,
-      path   => "${settings::confdir}/azure.conf",
-    ;
 
-    'azure-subscription_id':
-      setting => 'azure.subscription_id',
-      value   => $subscription_id,
-    ;
-
-    'azure-tenant_id':
-      setting => 'azure.tenant_id',
-      value   => $tenant_id,
-    ;
-
-    'azure-client_id':
-      setting => 'azure.client_id',
-      value   => $client_id,
-    ;
-
-    'azure-client_secret':
-      setting => 'azure.client_secret',
-      value   => $client_secret,
-    ;
+  exec { 'azure-cli-login':
+    command => Sensitive("/usr/bin/az login --service-principal -u ${client_id} -p ${client_secret.unwrap} --tenant ${tenant_id}"),
+    unless  => '/usr/bin/az account show',
   }
 }

--- a/manifests/azure.pp
+++ b/manifests/azure.pp
@@ -20,7 +20,7 @@ class node_orchestration::azure (
     }
 
     default: {
-      fail("Azure CLI installation not handled for ${facts['os']['family']}")
+      notice("Azure CLI installation not handled for ${facts['os']['family']}")
     }
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -11,10 +11,6 @@
       "version_requirement": ">= 2.0.0 < 3.0.0"
     },
     {
-      "name": "puppetlabs-hocon",
-      "version_requirement": ">= 1.0.0 < 2.0.0"
-    },
-    {
       "name": "puppetlabs-inifile",
       "version_requirement": ">= 5.0.0 < 7.0.0"
     },

--- a/metadata.json
+++ b/metadata.json
@@ -11,6 +11,10 @@
       "version_requirement": ">= 2.0.0 < 3.0.0"
     },
     {
+      "name": "puppetlabs-hocon",
+      "version_requirement": ">= 1.0.0 < 2.0.0"
+    },
+    {
       "name": "puppetlabs-inifile",
       "version_requirement": ">= 5.0.0 < 7.0.0"
     },

--- a/plans/bootstrap_agent.pp
+++ b/plans/bootstrap_agent.pp
@@ -14,9 +14,14 @@ plan node_orchestration::bootstrap_agent (
   $api_token       = lookup('node_orchestration::api_token', String)
 
   if $password {
-    $ssh_private_key = undef
+    $sensitive_parameters = {
+      'password' => $password.unwrap,
+    }
   } else {
     $ssh_private_key = lookup('node_orchestration::ssh_private_key', String)
+    $sensitive_parameters = {
+      'private-key-content' => $ssh_private_key,
+    }
   }
 
   $type_header = 'Content-Type: application/json'
@@ -31,10 +36,7 @@ plan node_orchestration::bootstrap_agent (
       'run-as'   => 'root',
       'hostname' => $hostname,
     },
-    'sensitive_parameters' => {
-      'password'            => $password,
-      'private-key-content' => $ssh_private_key,
-    },
+    'sensitive_parameters' => $sensitive_parameters,
     'duplicates'           => 'replace',
   }.to_json
 

--- a/plans/bootstrap_agent.pp
+++ b/plans/bootstrap_agent.pp
@@ -1,0 +1,48 @@
+# Register a new node in the PE inventory and run pe_bootstrap against it
+#
+# @param name The desired node certname
+# @param user The SSH user to bootstrap with
+# @param hostname The real hostname or IP address of the node to bootstrap
+plan node_orchestration::bootstrap_agent (
+  String $name,
+  String $user,
+  Stdlib::Host $hostname,
+) {
+  $task_server     = lookup('node_orchestration::task_server', String)
+  $puppet_server   = lookup('node_orchestration::puppet_server', String, 'first', $task_server)
+  $api_token       = lookup('node_orchestration::api_token', String)
+  $ssh_private_key = lookup('node_orchestration::ssh_private_key', String)
+
+  $type_header = 'Content-Type: application/json'
+  $auth_header = "X-Authentication: ${api_token}"
+  $uri = 'https://localhost:8143/inventory/v1/command/create-connection'
+
+  $connection_config = {
+    'certnames'            => [$name],
+    'type'                 => 'ssh',
+    'parameters'           => {
+      'user'     => $user,
+      'run-as'   => 'root',
+      'hostname' => $hostname,
+    },
+    'sensitive_parameters' => {
+      'private-key-content' => $ssh_private_key,
+    },
+    'duplicates'           => 'replace',
+  }.to_json
+
+  $curl_command = [
+    '/usr/bin/curl', '--insecure',
+    '--header', $type_header,
+    '--header', $auth_header,
+    '--request', 'POST', $uri,
+    '--data', $connection_config,
+  ].shellquote
+
+  run_command($curl_command, $task_server, 'Register inventory connection to the new instance')
+
+  run_task('pe_bootstrap', $name, 'Bootstrap the Puppet agent', {
+    certname => $name,
+    server   => $puppet_server,
+  })
+}

--- a/plans/bootstrap_agent.pp
+++ b/plans/bootstrap_agent.pp
@@ -3,30 +3,25 @@
 # @param name The desired node certname
 # @param hostname The real hostname or IP address of the node to bootstrap
 # @param user The SSH user to bootstrap with
-#
-# @api private
 plan node_orchestration::bootstrap_agent (
   String $name,
   Stdlib::Host $hostname,
-  Enum['ssh', 'winrm'] $connection_type,
   String $user,
   Optional[Sensitive] $password = undef,
   Optional[String] $role = undef,
 ) {
-  $task_server   = lookup('node_orchestration::task_server', String)
-  $puppet_server = lookup('node_orchestration::puppet_server', String, 'first', $task_server)
-  $api_token     = lookup('node_orchestration::api_token', String)
+  $task_server     = lookup('node_orchestration::task_server', String)
+  $puppet_server   = lookup('node_orchestration::puppet_server', String, 'first', $task_server)
+  $api_token       = lookup('node_orchestration::api_token', String)
 
   if $password {
     $sensitive_parameters = {
       'password' => $password.unwrap,
     }
-  } elsif $connection_type == 'ssh' {
+  } else {
     $sensitive_parameters = {
       'private-key-content' => lookup('node_orchestration::ssh_private_key', String),
     }
-  } else {
-    fail("Password is required for connection type '${connection_type}'")
   }
 
   $type_header = 'Content-Type: application/json'
@@ -35,7 +30,7 @@ plan node_orchestration::bootstrap_agent (
 
   $connection_config = {
     'certnames'            => [$name],
-    'type'                 => $connection_type,
+    'type'                 => 'ssh',
     'parameters'           => {
       'user'     => $user,
       'run-as'   => 'root',

--- a/plans/create_azure_vm.pp
+++ b/plans/create_azure_vm.pp
@@ -21,7 +21,6 @@ plan node_orchestration::create_azure_vm (
   Optional[Integer] $os_disk_size = undef,
   Array[Integer] $data_disk_sizes = [],
   Optional[String] $role = undef,
-  Boolean $windows = false,
 ) {
   # Let defaults be defined in Hiera, overridden with parameters
   $real_image_id       = pick($image_id, lookup('node_orchestration::az_image_id', Optional[String], 'first', undef))
@@ -77,18 +76,11 @@ plan node_orchestration::create_azure_vm (
     $ip_address = $vm_info['privateIpAddress']
   }
 
-  if $windows {
-    $connection_type = 'winrm'
-  } else {
-    $connection_type = 'ssh'
-  }
-
   run_plan('node_orchestration::bootstrap_agent', {
-    name            => $vm_name,
-    hostname        => $ip_address,
-    connection_type => $connection_type,
-    user            => $real_admin_user,
-    password        => $real_admin_password,
-    role            => $role,
+    name     => $vm_name,
+    hostname => $ip_address,
+    user     => $real_admin_user,
+    password => $real_admin_password,
+    role     => $role,
   })
 }

--- a/plans/create_azure_vm.pp
+++ b/plans/create_azure_vm.pp
@@ -12,7 +12,7 @@ plan node_orchestration::create_azure_vm (
   # Let defaults be defined in Hiera, overridden with parameters
   $real_image_id       = pick($image_id, lookup('node_orchestration::az_image_id', Optional[String], 'first', undef))
   $real_admin_user     = pick($admin_user, lookup('node_orchestration::az_admin_user', Optional[String], 'first', undef))
-  $real_key_name       = pick($key_name, lookup('node_orchestration::az_key_name', Optional[String], 'first', undef))
+  $real_admin_password = pick($admin_user, lookup('node_orchestration::az_admin_password', Optional[String], 'first', undef))
   $real_resource_group = pick($resource_group, lookup('node_orchestration::az_resource_group', Optional[String], 'first', undef))
 
   $task_server     = lookup('node_orchestration::task_server', String)
@@ -28,18 +28,23 @@ plan node_orchestration::create_azure_vm (
     '-g', $real_resource_group,
     '--image', $real_image_id,
     '--size', $vm_sizes[$size],
+
+    # Avoid SSH pubkey b/c Azure only supports ssh-rsa, for which
+    # PE wants to use SHA1 hashes disallowed by modern OpenSSH
     '--admin-username', $real_admin_user,
-    '--ssh-key-name', $real_key_name,
+    '--admin-password', $real_admin_password,
+    '--authentication-type', 'password',
   ].shellquote
 
   $vm_info = run_command($vm_create_command, $task_server, 'Create the VM').first.value['stdout'].parsejson
 
   log::info('Waiting for instance to finish booting')
-  ctrl::sleep(60)
+  ctrl::sleep(20)
 
   run_plan('node_orchestration::bootstrap_agent', {
     name     => $name,
-    user     => $real_admin_user,
     hostname => $vm_info['publicIpAddress'],
+    user     => $real_admin_user,
+    password => $real_admin_password,
   })
 }

--- a/plans/create_azure_vm.pp
+++ b/plans/create_azure_vm.pp
@@ -6,13 +6,13 @@ plan node_orchestration::create_azure_vm (
   Enum['small', 'medium', 'large'] $size,
   Optional[String] $image_id = undef,
   Optional[String] $admin_user = undef,
-  Optional[String] $key_name = undef,
+  Optional[Sensitive] $admin_password = undef,
   Optional[String] $resource_group = undef,
 ) {
   # Let defaults be defined in Hiera, overridden with parameters
   $real_image_id       = pick($image_id, lookup('node_orchestration::az_image_id', Optional[String], 'first', undef))
   $real_admin_user     = pick($admin_user, lookup('node_orchestration::az_admin_user', Optional[String], 'first', undef))
-  $real_admin_password = pick($admin_user, lookup('node_orchestration::az_admin_password', Optional[String], 'first', undef))
+  $real_admin_password = pick($admin_password, lookup('node_orchestration::az_admin_password', Optional[Sensitive], 'first', undef))
   $real_resource_group = pick($resource_group, lookup('node_orchestration::az_resource_group', Optional[String], 'first', undef))
 
   $task_server     = lookup('node_orchestration::task_server', String)
@@ -32,7 +32,7 @@ plan node_orchestration::create_azure_vm (
     # Avoid SSH pubkey b/c Azure only supports ssh-rsa, for which
     # PE wants to use SHA1 hashes disallowed by modern OpenSSH
     '--admin-username', $real_admin_user,
-    '--admin-password', $real_admin_password,
+    '--admin-password', $real_admin_password.unwrap,
     '--authentication-type', 'password',
   ].shellquote
 

--- a/plans/create_azure_vm.pp
+++ b/plans/create_azure_vm.pp
@@ -21,6 +21,7 @@ plan node_orchestration::create_azure_vm (
   Optional[Integer] $os_disk_size = undef,
   Array[Integer] $data_disk_sizes = [],
   Optional[String] $role = undef,
+  Boolean $windows = false,
 ) {
   # Let defaults be defined in Hiera, overridden with parameters
   $real_image_id       = pick($image_id, lookup('node_orchestration::az_image_id', Optional[String], 'first', undef))
@@ -76,11 +77,18 @@ plan node_orchestration::create_azure_vm (
     $ip_address = $vm_info['privateIpAddress']
   }
 
+  if $windows {
+    $connection_type = 'winrm'
+  } else {
+    $connection_type = 'ssh'
+  }
+
   run_plan('node_orchestration::bootstrap_agent', {
-    name     => $vm_name,
-    hostname => $ip_address,
-    user     => $real_admin_user,
-    password => $real_admin_password,
-    role     => $role,
+    name            => $vm_name,
+    hostname        => $ip_address,
+    connection_type => $connection_type,
+    user            => $real_admin_user,
+    password        => $real_admin_password,
+    role            => $role,
   })
 }

--- a/plans/create_azure_vm.pp
+++ b/plans/create_azure_vm.pp
@@ -1,0 +1,39 @@
+# Create an Azure VM with default settings
+#
+# @param name The name of the instance to create
+plan node_orchestration::create_azure_vm (
+  String $name,
+  Enum['small', 'medium', 'large'] $size,
+  Optional[String] $image_id = undef,
+  Optional[String] $admin_user = undef,
+  Optional[String] $key_name = undef,
+  Optional[String] $resource_group = undef,
+) {
+  # Let defaults be defined in Hiera, overridden with parameters
+  $real_image_id       = pick($image_id, lookup('node_orchestration::az_image_id', Optional[String], 'first', undef))
+  $real_admin_user     = pick($admin_user, lookup('node_orchestration::az_admin_user', Optional[String], 'first', undef))
+  $real_key_name       = pick($key_name, lookup('node_orchestration::az_key_name', Optional[String], 'first', undef))
+  $real_resource_group = pick($resource_group, lookup('node_orchestration::az_resource_group', Optional[String], 'first', undef))
+
+  $task_server     = lookup('node_orchestration::task_server', String)
+  $puppet_server   = lookup('node_orchestration::puppet_server', String, 'first', $task_server)
+  $api_token       = lookup('node_orchestration::api_token', String)
+  $ssh_private_key = lookup('node_orchestration::ssh_private_key', String)
+  $vm_sizes        = lookup('node_orchestration::az_vm_sizes', Hash)
+
+  unless $vm_sizes[$size] {
+    fail("Size '${size}' not found in 'node_orchestration::az_vm_sizes' lookup hash")
+  }
+
+  $vm_create_command = [
+    '/usr/bin/az', 'vm', 'create',
+    '-n', $name,
+    '-g', $real_resource_group,
+    '--image', $real_image_id,
+    '--size', $vm_sizes[$size],
+    '--admin-username', $real_admin_user,
+    '--ssh-key-name', $real_key_name,
+  ].shellquote
+
+  run_command($vm_create_command, $task_server, 'Create the VM')
+}

--- a/plans/create_azure_vm.pp
+++ b/plans/create_azure_vm.pp
@@ -1,6 +1,11 @@
 # Create an Azure VM with default settings
 #
-# @param name The name of the instance to create
+# @param name The name of the VM to create
+# @param size The type of VM to create (small, medium, large)
+# @param image_id Overrides the default image ID set in Hiera
+# @param admin_user Overrides the initial VM username set in Hiera
+# @param admin_password Overrides the initial VM password set in Hiera
+# @param resource_group Overrides the resource group set in Hiera
 plan node_orchestration::create_azure_vm (
   String $name,
   Enum['small', 'medium', 'large'] $size,

--- a/plans/create_azure_vm.pp
+++ b/plans/create_azure_vm.pp
@@ -9,6 +9,7 @@
 # @param resource_group Overrides the resource group set in Hiera
 # @param os_disk_size If set, the size of the OS disk in GB. Otherwise, use Azure defaults.
 # @param data_disk_sizes The sizes of the data disks to attach in GB
+# @param role Set the `pp_role` extension request (trusted fact) to this value
 plan node_orchestration::create_azure_vm (
   String $vm_name,
   Enum['small', 'medium', 'large'] $size,
@@ -19,6 +20,7 @@ plan node_orchestration::create_azure_vm (
   Optional[String] $resource_group = undef,
   Optional[Integer] $os_disk_size = undef,
   Array[Integer] $data_disk_sizes = [],
+  Optional[String] $role = undef,
 ) {
   # Let defaults be defined in Hiera, overridden with parameters
   $real_image_id       = pick($image_id, lookup('node_orchestration::az_image_id', Optional[String], 'first', undef))
@@ -79,5 +81,6 @@ plan node_orchestration::create_azure_vm (
     hostname => $ip_address,
     user     => $real_admin_user,
     password => $real_admin_password,
+    role     => $role,
   })
 }

--- a/plans/create_azure_vm.pp
+++ b/plans/create_azure_vm.pp
@@ -1,6 +1,6 @@
 # Create an Azure VM with default settings
 #
-# @param name The name of the VM to create
+# @param vm_name The name of the VM to create
 # @param size The type of VM to create (small, medium, large)
 # @param image_id Overrides the default image ID set in Hiera
 # @param admin_user Overrides the initial VM username set in Hiera
@@ -10,7 +10,7 @@
 # @param os_disk_size If set, the size of the OS disk in GB. Otherwise, use Azure defaults.
 # @param data_disk_sizes The sizes of the data disks to attach in GB
 plan node_orchestration::create_azure_vm (
-  String $name,
+  String $vm_name,
   Enum['small', 'medium', 'large'] $size,
   Optional[String] $image_id = undef,
   Optional[String] $admin_user = undef,
@@ -24,8 +24,8 @@ plan node_orchestration::create_azure_vm (
   $real_image_id       = pick($image_id, lookup('node_orchestration::az_image_id', Optional[String], 'first', undef))
   $real_admin_user     = pick($admin_user, lookup('node_orchestration::az_admin_user', Optional[String], 'first', undef))
   $real_admin_password = pick($admin_password, lookup('node_orchestration::az_admin_password', Optional[Sensitive], 'first', undef))
-  $real_resource_group = pick($resource_group, lookup('node_orchestration::az_resource_group', Optional[String], 'first', undef))
   $real_public_ip_addr = pick($public_ip_address, lookup('node_orchestration::az_public_ip_address', Optional[Boolean], 'first', true))
+  $real_resource_group = pick($resource_group, lookup('node_orchestration::az_resource_group', Optional[String], 'first', undef))
 
   $task_server     = lookup('node_orchestration::task_server', String)
   $vm_sizes        = lookup('node_orchestration::az_vm_sizes', Hash)
@@ -36,7 +36,7 @@ plan node_orchestration::create_azure_vm (
 
   $vm_create_command = [
     '/usr/bin/az', 'vm', 'create',
-    '-n', $name,
+    '-n', $vm_name,
     '-g', $real_resource_group,
     '--image', $real_image_id,
     '--size', $vm_sizes[$size],
@@ -75,7 +75,7 @@ plan node_orchestration::create_azure_vm (
   }
 
   run_plan('node_orchestration::bootstrap_agent', {
-    name     => $name,
+    name     => $vm_name,
     hostname => $ip_address,
     user     => $real_admin_user,
     password => $real_admin_password,

--- a/plans/launch_ec2_instance.pp
+++ b/plans/launch_ec2_instance.pp
@@ -14,7 +14,7 @@ plan node_orchestration::launch_ec2_instance (
   Optional[String] $image_id = undef,
   Optional[String] $ami_user = undef,
   Optional[String] $key_name = undef,
-  Optional[Variant[String, Array[String]]] $security_groups = undef,
+  Optional[Array[String]] $security_groups = undef,
   Optional[String] $subnet   = undef,
   Optional[String] $region   = undef,
 ) {
@@ -22,7 +22,7 @@ plan node_orchestration::launch_ec2_instance (
   $real_image_id = pick($image_id, lookup('node_orchestration::ec2_image_id', Optional[String], 'first', undef))
   $real_ami_user = pick($ami_user, lookup('node_orchestration::ec2_ami_user', Optional[String], 'first', undef))
   $real_key_name = pick($key_name, lookup('node_orchestration::ec2_key_name', Optional[String], 'first', undef))
-  $real_sgs      = pick($security_groups, lookup('node_orchestration::ec2_security_groups', Optional[Variant[String, Array[String]]], 'first', undef))
+  $real_sgs      = pick($security_groups, lookup('node_orchestration::ec2_security_groups', Optional[Array[String]], 'first', undef))
   $real_subnet   = pick($subnet, lookup('node_orchestration::ec2_subnet', Optional[String], 'first', undef))
   $real_region   = pick($region, lookup('node_orchestration::ec2_region', Optional[String], 'first', undef))
 
@@ -48,7 +48,8 @@ plan node_orchestration::launch_ec2_instance (
       break()
     }
 
-    $resource = run_command("/opt/puppetlabs/bin/puppet resource --to_yaml ec2_instance ${name.shellquote}", $task_server, 'Check if the instance is running', {
+    $check_cmd = shellquote('/opt/puppetlabs/bin/puppet', 'resource', '--to_yaml', 'ec2_instance', $name)
+    $resource = run_command($check_cmd, $task_server, 'Check if the instance is running', {
       _env_vars => { 'AWS_REGION' => $real_region },
     }).first.value['stdout'].parseyaml
 

--- a/plans/launch_ec2_instance.pp
+++ b/plans/launch_ec2_instance.pp
@@ -68,7 +68,7 @@ plan node_orchestration::launch_ec2_instance (
 
   run_plan('node_orchestration::bootstrap_agent', {
     name     => $name,
-    user     => $real_ami_user,
     hostname => $hostname,
+    user     => $real_ami_user,
   })
 }

--- a/plans/launch_ec2_instance.pp
+++ b/plans/launch_ec2_instance.pp
@@ -33,7 +33,7 @@ plan node_orchestration::launch_ec2_instance (
   $instance_types  = lookup('node_orchestration::ec2_instance_types', Hash)
 
   unless $instance_types[$size] {
-    fail("Size '${size}' not found in 'node_orchestration_ec2_instance_types' lookup hash")
+    fail("Size '${size}' not found in 'node_orchestration::ec2_instance_types' lookup hash")
   }
 
   run_task('aws::create_instance', $task_server, 'Create the instance', {

--- a/plans/launch_ec2_instance.pp
+++ b/plans/launch_ec2_instance.pp
@@ -11,6 +11,7 @@
 # @param subnet Overrides the default subnet name set in Hiera
 # @param region Overrides the default region set in Hiera
 # @param os_disk_size If set, the size of the OS disk in GB. Otherwise, use EC2 defaults.
+# @param role Set the `pp_role` extension request (trusted fact) to this value
 plan node_orchestration::launch_ec2_instance (
   String $instance_name,
   Enum['small', 'medium', 'large'] $size,
@@ -22,6 +23,7 @@ plan node_orchestration::launch_ec2_instance (
   Optional[String] $subnet = undef,
   Optional[String] $region = undef,
   Optional[Integer] $os_disk_size = undef,
+  Optional[String] $role = undef,
 ) {
   # Let defaults be defined in Hiera, overridden with parameters
   $real_image_id       = pick($image_id, lookup('node_orchestration::ec2_image_id', Optional[String], 'first', undef))
@@ -97,5 +99,6 @@ plan node_orchestration::launch_ec2_instance (
     name     => $instance_name,
     hostname => $ip_address,
     user     => $real_ami_user,
+    role     => $role,
   })
 }

--- a/plans/launch_ec2_instance.pp
+++ b/plans/launch_ec2_instance.pp
@@ -48,6 +48,8 @@ plan node_orchestration::launch_ec2_instance (
     $block_devices = undef
   }
 
+  apply_prep($task_server)
+
   apply($task_server, '_description' => 'Create the instance') {
     ec2_instance { $instance_name:
       ensure                      => running,

--- a/plans/launch_ec2_instance.pp
+++ b/plans/launch_ec2_instance.pp
@@ -48,8 +48,6 @@ plan node_orchestration::launch_ec2_instance (
     $block_devices = undef
   }
 
-  apply_prep($task_server)
-
   apply($task_server, '_description' => 'Create the instance') {
     ec2_instance { $instance_name:
       ensure                      => running,

--- a/plans/launch_ec2_instance.pp
+++ b/plans/launch_ec2_instance.pp
@@ -5,6 +5,7 @@
 # @param image_id Overrides the default AMI set in Hiera
 # @param ami_user Overrides the default AMI username set in Hiera
 # @param key_name Overrides the default SSH key name set in Hiera
+# @param public_ip_address Overrides Hiera setting on whether to assign a public IP address
 # @param security_groups Overrides the default SG or list of SGs set in Hiera
 # @param subnet Overrides the default subnet name set in Hiera
 # @param region Overrides the default region set in Hiera
@@ -14,17 +15,19 @@ plan node_orchestration::launch_ec2_instance (
   Optional[String] $image_id = undef,
   Optional[String] $ami_user = undef,
   Optional[String] $key_name = undef,
+  Optional[Boolean] $public_ip_address = undef,
   Optional[Array[String]] $security_groups = undef,
   Optional[String] $subnet   = undef,
   Optional[String] $region   = undef,
 ) {
   # Let defaults be defined in Hiera, overridden with parameters
-  $real_image_id = pick($image_id, lookup('node_orchestration::ec2_image_id', Optional[String], 'first', undef))
-  $real_ami_user = pick($ami_user, lookup('node_orchestration::ec2_ami_user', Optional[String], 'first', undef))
-  $real_key_name = pick($key_name, lookup('node_orchestration::ec2_key_name', Optional[String], 'first', undef))
-  $real_sgs      = pick($security_groups, lookup('node_orchestration::ec2_security_groups', Optional[Array[String]], 'first', undef))
-  $real_subnet   = pick($subnet, lookup('node_orchestration::ec2_subnet', Optional[String], 'first', undef))
-  $real_region   = pick($region, lookup('node_orchestration::ec2_region', Optional[String], 'first', undef))
+  $real_image_id       = pick($image_id, lookup('node_orchestration::ec2_image_id', Optional[String], 'first', undef))
+  $real_ami_user       = pick($ami_user, lookup('node_orchestration::ec2_ami_user', Optional[String], 'first', undef))
+  $real_key_name       = pick($key_name, lookup('node_orchestration::ec2_key_name', Optional[String], 'first', undef))
+  $real_public_ip_addr = pick($public_ip_address, lookup('node_orchestration::ec2_public_ip_address', Optional[Boolean], 'first', true))
+  $real_sgs            = pick($security_groups, lookup('node_orchestration::ec2_security_groups', Optional[Array[String]], 'first', undef))
+  $real_subnet         = pick($subnet, lookup('node_orchestration::ec2_subnet', Optional[String], 'first', undef))
+  $real_region         = pick($region, lookup('node_orchestration::ec2_region', Optional[String], 'first', undef))
 
   $task_server     = lookup('node_orchestration::task_server', String)
   $instance_types  = lookup('node_orchestration::ec2_instance_types', Hash)
@@ -33,15 +36,20 @@ plan node_orchestration::launch_ec2_instance (
     fail("Size '${size}' not found in 'node_orchestration::ec2_instance_types' lookup hash")
   }
 
-  run_task('aws::create_instance', $task_server, 'Create the instance', {
-    image_id        => $real_image_id,
-    instance_type   => $instance_types[$size],
-    key_name        => $real_key_name,
-    name            => $name,
-    region          => $real_region,
-    security_groups => $real_sgs,
-    subnet          => $real_subnet,
-  })
+  $instance_create_cmd = [
+    '/opt/puppetlabs/bin/puppet', 'resource',
+    'ec2_instance', $name,
+    'ensure=running',
+    "image_id=${real_image_id}",
+    "instance_type=${instance_types[$size]}",
+    "key_name=${real_key_name}",
+    "region=${real_region}",
+    "associate_public_ip_address=${real_public_ip_addr}",
+    "security_groups=${real_sgs.join(',')}",
+    "subnet=${real_subnet}",
+  ].shellquote
+
+  run_command($instance_create_cmd, $task_server, 'Create the instance')
 
   $hostname = Integer[0, 6].reduce(undef) |$result, $i| {
     if $result {
@@ -56,7 +64,12 @@ plan node_orchestration::launch_ec2_instance (
     if $resource['ec2_instance'] and $resource['ec2_instance'][$name] and $resource['ec2_instance'][$name]['ensure'] == 'running' {
       log::info('Waiting for instance to finish booting')
       ctrl::sleep(20)
-      $resource['ec2_instance'][$name]['public_dns_name']
+
+      if $real_public_ip_addr {
+        $resource['ec2_instance'][$name]['public_dns_name']
+      } else {
+        $resource['ec2_instance'][$name]['private_dns_name']
+      }
     } else {
       log::info('Instance is not running yet')
       ctrl::sleep(10)


### PR DESCRIPTION
Implement a plan similar to `node_orchestration::launch_ec2_instance` but for Azure. The new plan, `node_orchestration::create_azure_vm`, uses the Azure CLI to interact with Azure to create the requested VM in a Puppet-managed resource group. It then registers the VM with the Puppet inventory and bootstraps the Puppet agent.

Additional support was added to configure OS and data disk sizes and to control the public IP configuration.

An initial attempt was made at adding support for Windows nodes but automating the WinRM connection for bootstraping the agent may not be possible based on the instructions at https://learn.microsoft.com/en-us/azure/virtual-machines/windows/connect-winrm.